### PR TITLE
Add generics to query API

### DIFF
--- a/src/Domain/Query/Query.php
+++ b/src/Domain/Query/Query.php
@@ -2,7 +2,9 @@
 
 namespace Mediagone\CQRS\Bus\Domain\Query;
 
-
+/**
+ * @template T
+ */
 interface Query
 {
     // The Query interface implements no method definition because it is just a PHP object that hold data.

--- a/src/Domain/Query/Query.php
+++ b/src/Domain/Query/Query.php
@@ -2,6 +2,7 @@
 
 namespace Mediagone\CQRS\Bus\Domain\Query;
 
+
 /**
  * @template T
  */

--- a/src/Domain/Query/QueryBus.php
+++ b/src/Domain/Query/QueryBus.php
@@ -7,7 +7,11 @@ interface QueryBus
 {
     /**
      * Routes a query to its executor and returns the result.
-     * @return mixed The result of the query.
+     *
+     * @template T
+     *
+     * @param Query<T> $query
+     * @return T The result of the query.
      */
     public function find(Query $query);
 }

--- a/src/Domain/Query/QueryFetcher.php
+++ b/src/Domain/Query/QueryFetcher.php
@@ -6,8 +6,10 @@ namespace Mediagone\CQRS\Bus\Domain\Query;
 interface QueryFetcher
 {
     /**
-     * @return mixed The result of the query.
+     * @template T
+     *
+     * @param Query<T> $query
+     * @return T The result of the query.
      */
     public function fetch(Query $query);
-    
 }

--- a/src/Domain/Query/SpecificationQuery.php
+++ b/src/Domain/Query/SpecificationQuery.php
@@ -4,10 +4,12 @@ namespace Mediagone\CQRS\Bus\Domain\Query;
 
 use Mediagone\Doctrine\Specifications\SpecificationCompound;
 
+
 /**
  * @template T
  * @implements Query<T>
  */
 abstract class SpecificationQuery extends SpecificationCompound implements Query
 {
+    
 }

--- a/src/Domain/Query/SpecificationQuery.php
+++ b/src/Domain/Query/SpecificationQuery.php
@@ -4,8 +4,10 @@ namespace Mediagone\CQRS\Bus\Domain\Query;
 
 use Mediagone\Doctrine\Specifications\SpecificationCompound;
 
-
+/**
+ * @template T
+ * @implements Query<T>
+ */
 abstract class SpecificationQuery extends SpecificationCompound implements Query
 {
-
 }


### PR DESCRIPTION
Example of usage with `SpecificationQuery`:

```php
/**
 * @template T
 * @extends SpecificationQuery<T>
 */
final class ManySomeEntity extends SpecificationQuery
{
    /**
     * @return static<SomeEntity[]>
     */
    public static function asEntity(): self
    {
        // …
    }

    /**
     * @return static<int>
     */
    public static function asCount(): self
    {
        // …
    }

    /**
     * @return self<T>
     */
    public function orderBySomeField: self
    {
        // …

        return $this;
    }
}

$entities = $this->queryBus->find(ManySomeEntity::asEntity());
\PHPStan\dumpType($entities); // array<SomeEntity>
```